### PR TITLE
Small change to make GCal's Quick Add parse dates and times

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -89,22 +89,8 @@ utils.processEvent = function(event) {
 utils.getGCalUrl_ = function(event) {
   // Basic event information: Title, Start, End.
   var link =
-      'https://www.google.com/calendar/event?action=TEMPLATE&trp=false&text=' +
+      'https://www.google.com/calendar/event?action=TEMPLATE&trp=false&ctext=' +
       encodeURIComponent(event.title);
-
-  // Dates could be optional.
-  if (event.start) {
-    // If the time is exactly midnight, this might be an all-day event, so skip
-    // the T000000 part.
-    link += '&dates=' +
-        moment(event.start).format('YYYYMMDDTHHmmss').replace('T000000', '');
-
-    // Even if start date is present, end date could be missing.
-    if (event.end) {
-      link += '/' +
-          moment(event.end).format('YYYYMMDDTHHmmss').replace('T000000', '');
-    }
-  }
 
   // Location
   if (event.location) {


### PR DESCRIPTION
Made a change to the url generation for creating a new event based on a user's selection when using the context menu.

So something like:
"The NFL Super Bowl is on Sunday, February 3, 2013 at 9pm"
can be added more easily.
