### PR TITLE
Switch to using JS timestamps (milliseconds since the epoch) instead of ...

### DIFF
--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -126,8 +126,8 @@ browseraction.installButtonClickHandlers_ = function() {
 
     var event = /** @type {CalendarEvent} */ {};
     event.title = event.description = $('#event-title').val().toString();
-    event.start = moment($('#from-date').val() + ' ' + $('#from-time').val(), formats).toDate();
-    event.end = moment($('#to-date').val() + ' ' + $('#to-time').val(), formats).toDate();
+    event.start = moment($('#from-date').val() + ' ' + $('#from-time').val(), formats).valueOf();
+    event.end = moment($('#to-date').val() + ' ' + $('#to-time').val(), formats).valueOf();
     event = utils.processEvent(event);
 
     chrome.tabs.create({'url': event.gcal_url});
@@ -224,7 +224,7 @@ browseraction.showEventsFromFeed_ = function(events) {
 browseraction.createEventDiv_ = function(event) {
   var start = utils.fromIso8601(event.start);
   var end = utils.fromIso8601(event.end);
-  var now = new Date();
+  var now = moment().valueOf();
 
   var eventDiv = $('<div>')
       .addClass('event')
@@ -234,8 +234,12 @@ browseraction.createEventDiv_ = function(event) {
     chrome.tabs.create({'url': $(this).attr('data-url')});
   });
 
+  if (!start) {  // Some events detected via microformats are malformed.
+    return eventDiv;
+  }
+
   var isNewEvent = !event.feed;
-  var isHappeningNow = start.valueOf() < now.getTime() && end.valueOf() >= now.getTime();
+  var isHappeningNow = start.valueOf() < now && end.valueOf() >= now;
   if (isNewEvent) {  // This event has not yet been added to the user's calendar.
     $('<div>').addClass('feed-color')
         .css({'background-color': '#e6932e'})

--- a/src/feeds.js
+++ b/src/feeds.js
@@ -138,8 +138,8 @@ feeds.getEventsFrom_ = function(feed, callback) {
         events.push({
           feed: feed,
           title: eventEntry.find('title').text(),
-          start: start ? start.toDate() : null,
-          end: end ? end.toDate() : null,
+          start: start ? start.valueOf() : null,
+          end: end ? end.valueOf() : null,
           description: eventEntry.find('content').text(),
           location: eventEntry.find('where').attr('valueString'),
           reminder: eventEntry.find('when').find('reminder').attr('minutes'),
@@ -182,7 +182,7 @@ feeds.fetch = function() {
         allEvents = allEvents.concat(events);
         if (--pendingRequests === 0) {
           allEvents.sort(function(first, second) {
-            return first.start.getTime() - second.start.getTime();
+            return first.start - second.start;
           });
           feeds.events = allEvents;
           feeds.onFetched();
@@ -209,9 +209,8 @@ feeds.removePastEvents_ = function() {
   // empty calendar. Look at the end time instead of the start time, so that
   // events in progress are retained.
   var futureAndCurrentEvents = [];
-  var now = new Date();
   for (var i = 0; i < feeds.events.length; ++i) {
-    if (feeds.events[i].end > now.getTime()) {
+    if (feeds.events[i].end > moment().valueOf()) {
       futureAndCurrentEvents.push(feeds.events[i]);
     }
   }
@@ -237,9 +236,8 @@ feeds.determineNextEvents_ = function() {
   }
 
   feeds.nextEvents = [];
-  var now = new Date();
   for (var i = 0; i < feeds.events.length; ++i) {
-    if (feeds.events[i].start.getTime() < now.getTime()) {
+    if (feeds.events[i].start < moment().valueOf()) {
       continue;  // All-day events for today, or events from earlier in the day.
     }
 
@@ -253,7 +251,7 @@ feeds.determineNextEvents_ = function() {
     // At this point in the loop, we know there is at least one next event
     // starting at a specific time. Now we need to pick any more events that may
     // exist, that all start at the exact same time as the first event.
-    if (feeds.events[i].start.getTime() == feeds.nextEvents[0].start.getTime()) {
+    if (feeds.events[i].start == feeds.nextEvents[0].start) {
       feeds.nextEvents.push(feeds.events[i]);
     } else {
       break;

--- a/src/types.js
+++ b/src/types.js
@@ -54,9 +54,9 @@ function CalendarEvent() {}
 CalendarEvent.prototype.title = '';
 /** @type {string} */
 CalendarEvent.prototype.description = '';
-/** @type {string} */
+/** @type {number} */
 CalendarEvent.prototype.start = '';
-/** @type {string} */
+/** @type {number} */
 CalendarEvent.prototype.end = '';
 /** @type {string} */
 CalendarEvent.prototype.url = '';

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,11 +46,11 @@ utils.processEvent = function(event) {
     var startMoment = moment(event.start);
     if (startMoment.hours() === 0 && startMoment.minutes() === 0) {
       // Assume it's an all-day event if hh=0 & mm=0.
-      event.end = startMoment.add('d', 1).format();
+      event.end = startMoment.add('d', 1).valueOf();
     } else {
       // It's not an all-day event, so default to start + X hours, and the user
       // can tweak it before adding to their calendar.
-      event.end = startMoment.add('h', 2).format();
+      event.end = startMoment.add('h', 2).valueOf();
     }
   }
 
@@ -141,20 +141,24 @@ utils.getGCalUrl_ = function(event) {
  * @param {string|jQuery} s ISO 8601 date as a string.
  * @return {Moment} Parsed JavaScript date object.
  */
-utils.fromIso8601 = function(s) {
-  if (!s) {
+utils.fromIso8601 = function(date) {
+  if (!date) {
     return null;
   }
 
-  s = s.replace('Z', '+00:00');
-  return moment(s, [
-    'YYYY-MM-DDTHH:mm:ssZZ', 'YYYY-MM-DDTHHmmssZZ', 'YYYYMMDDTHHmmssZZ',
-    'YYYY-MM-DDTHH:mm:ss',   'YYYY-MM-DDTHHmmss',   'YYYYMMDDTHHmmss',
-    'YYYY-MM-DDTHH:mmZZ',    'YYYY-MM-DDTHHmmZZ',   'YYYYMMDDTHHmmZZ',
-    'YYYY-MM-DDTHH:mm',      'YYYY-MM-DDTHHmm',     'YYYYMMDDTHHmm',
-    'YYYY-MM-DDTHH',                                'YYYYMMDDTHH',
-    'YYYY-MM-DD',                                   'YYYYMMDD'
-  ]);
+  if (typeof date === 'string') {
+    date = date.replace('Z', '+00:00');
+    return moment(date, [
+      'YYYY-MM-DDTHH:mm:ssZZ', 'YYYY-MM-DDTHHmmssZZ', 'YYYYMMDDTHHmmssZZ',
+      'YYYY-MM-DDTHH:mm:ss',   'YYYY-MM-DDTHHmmss',   'YYYYMMDDTHHmmss',
+      'YYYY-MM-DDTHH:mmZZ',    'YYYY-MM-DDTHHmmZZ',   'YYYYMMDDTHHmmZZ',
+      'YYYY-MM-DDTHH:mm',      'YYYY-MM-DDTHHmm',     'YYYYMMDDTHHmm',
+      'YYYY-MM-DDTHH',                                'YYYYMMDDTHH',
+      'YYYY-MM-DD',                                   'YYYYMMDD'
+    ]);
+  } else {
+    return moment(date);
+  }
 };
 
 


### PR DESCRIPTION
...Date objects for message passing.

Chrome 30 Beta, without warning, started dropping Dates and instead
passes along blank Objects ({}) between background pages and browser
action pages.
