### PR TITLE
Improvements to Dutch translations

### DIFF
--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -5,7 +5,7 @@
   },
 
   "google_calendar_extension_desc": {
-    "message": "Check makkelijk Google Agenda en voeg nieuwe evenementen toe vanuit websites die je bezoekt.",
+    "message": "Check makkelijk Google Agenda en voeg nieuwe afspraken toe vanuit websites die je bezoekt.",
     "description": "Description of what this extension does."
   },
 
@@ -25,7 +25,7 @@
   },
 
   "add_an_event": {
-    "message": "Evenement toevoegen",
+    "message": "Nieuwe afspraak",
     "description": "Header that appears just above the form that lets users add custom events."
   },
 
@@ -35,22 +35,22 @@
   },
 
   "events_on_this_page": {
-    "message": "Evenement op deze pagina",
+    "message": "Gebeurtenissen op deze pagina",
     "description": "Title used in the browser action popup for the list of events detected on the current page."
   },
 
   "quick_add_button": {
-    "message": "Toevoegen",
+    "message": "Opslaan",
     "description": "Text on the button that adds a new event to the calendar from user input."
   },
 
   "no_events_today": {
-    "message": "Geen evenementen vandaag.",
+    "message": "Geen afspraken vandaag.",
     "description": "Message shown as a placeholder when there are no events today. It only applies to when there are no events today, not for other dates."
   },
 
   "authorization_required": {
-    "message": "Autoriseren Google Agenda",
+    "message": "Google Agenda Autoriseren",
     "description": "A message shown when the user needs to grant permission for this extension to read events from their calendar."
   },
 
@@ -60,7 +60,7 @@
   },
 
   "authorization_explanation": {
-    "message": "Met Google Agenda voor Chrome kunt u uw agenda controleren terwijl u andere websites bezoekt. Hiervoor moet je toegang verlenen tot uw agenda. Dit is een eenmalige installatie stap die vereist is voordat u deze app kunt gebruiken.",
+    "message": "Met Google Agenda voor Chrome kunt u uw agenda controleren terwijl u andere websites bezoekt. Hiervoor is toegang tot uw agenda nodig. Dit is een eenmalig vereiste installatiestap voordat u deze app kunt gebruiken.",
     "description": "A detailed message explaining the OAuth flow."
   },
 
@@ -75,12 +75,12 @@
   },
 
   "sync_now": {
-    "message": "Bijwerken van de lijst met evenementen van de server.",
+    "message": "Werk de lijst met afspraken bij vanaf de server",
     "description": "Alternate text for the icon that forces syncing the calendar right away."
   },
 
   "show_quick_add": {
-    "message": "Voeg een nieuw evenement door de evenementen details in te typen.",
+    "message": "Voeg een nieuwe afspraak toe door de gegevens van de afspraak in te typen.",
     "description": "Alternate text for the icon that shows the text area where users add details of new events."
   },
 
@@ -90,7 +90,7 @@
   },
 
   "fetching_feed": {
-    "message": "De lijst met evenement wordt bijgewerkt.",
+    "message": "De afsprakenlijst wordt bijgewerkt.",
     "description": "Tooltip text for when the extension is fetching the feed from the server."
   },
 
@@ -120,7 +120,7 @@
   },
 
   "option_show_time_until_next_event": {
-    "message": "Toon resterende tijd tot het volgende evenement.",
+    "message": "Toon resterende tijd tot de volgende afspraak.",
     "description": "The name of the option that tells the user that the extension will display the time on the badge."
   },
 
@@ -130,7 +130,7 @@
   },
 
   "debug_enable_logs": {
-    "message": "Enable logging. Logs worden lokaal opgeslagen. U kunt er voor kiezen deze mee te sturen met een bug.",
+    "message": "Logbestanden bijhouden. Logbestanden worden lokaal opgeslagen. U kunt er voor kiezen deze mee te sturen met een bug.",
     "description": "Text for a checkbox that enables logging."
   }
 }


### PR DESCRIPTION
Dutch translations were not consistent with the Google Calendar UI. Also, the word "Evenement" in Dutch does not really map 1-on-1 to "Event" in english. An "evenement" has connotations of something being organized for a large group of people, like a concert or festival.

I've replaced "evenement" with either "gebeurtenis" (which maps more closely to the english "event") when it concerns something on the page you're looking at, or afspraak ("appointment") when it concerns something that is in your calendar.