### PR TITLE
Update badge when no future events found

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -49,6 +49,11 @@
     "description": "Message shown as a placeholder when there are no events today. It only applies to when there are no events today, not for other dates."
   },
 
+  "no_upcoming_events": {
+    "message": "No upcoming events.",
+    "description": "Message shown as a placeholder when there are no future events at all. It applies both to today and all future dates."
+  },
+
   "authorization_required": {
     "message": "Authorize Google Calendar",
     "description": "A message shown when the user needs to grant permission for this extension to read events from their calendar."

--- a/src/feeds.js
+++ b/src/feeds.js
@@ -384,8 +384,12 @@ feeds.refreshUI = function() {
   feeds.removePastEvents_();
   feeds.determineNextEvents_();
 
-  // If there are no more next events to show, bail out.
+  // If there are no more next events to show, reset the badge and bail out.
   if (feeds.nextEvents.length === 0) {
+    background.updateBadge({
+      'text': '',
+      'title': chrome.i18n.getMessage('no_upcoming_events')
+    })
     return;
   }
 


### PR DESCRIPTION
This fixes #86, #124, and #147. The badge will now be updated when there are no future events instead of getting stuck on the last displayed message.