### PR TITLE
Troubleshooting translation strings

### DIFF
--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -165,22 +165,22 @@
   },
 
   "debug_enable_logs": {
-    "message": "Zapnout logování. Logy jsou uloženy lokálně. Můžete je poslat spolu s hlášením o chybě, pokud chcete.",
+    "message": "Zapnout logování. Logy jsou uloženy lokálně. Můžete je poslat spolu s hlášením o chybě pokud chcete.",
     "description": "Text for a checkbox that enables logging."
   },
 
-  "report_button": {
+  "report_issue_button": {
     "message": "Nahlásit problém",
     "description": "Text on the button that shows a debug information."
   },
 
-  "debug_information": {
-    "message": "Zkopírujte tyto ladící informace, přidejte detailní kroky, jak problém reprodukovat a připojte screenshot.",
+  "report_issue_steps": {
+    "message": "Zkopírujte tyto ladící informace, přidejte detailní kroky jak problém reprodukovat a připojte screenshot.",
     "description": "Text that tells the user what to write in debug information."
   },
 
   "report_create_issue": {
-    "message": "Poté vytvořte nový požadavek a vložte jej na",
+    "message": "Poté vytvořte nový issue na",
     "description": "Text that tells the user where to put a debug information."
   }
 }

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -180,7 +180,7 @@
   },
 
   "report_create_issue": {
-    "message": "Poté vytvořte nový issue a vložte jej na",
+    "message": "Poté vytvořte nový issue a vložte jej do issue trackeru níže.",
     "description": "Text that tells the user where to put a debug information."
   }
 }

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -53,7 +53,7 @@
     "message": "Žádné nadcházející události.",
     "description": "Message shown as a placeholder when there are no future events at all. It applies both to today and all future dates."
   },
- 
+
   "authorization_required": {
     "message": "Autorizovat Google Kalendář",
     "description": "A message shown when the user needs to grant permission for this extension to read events from their calendar."
@@ -144,8 +144,43 @@
     "description": "When a user does not have access to a particular calendar, the event title is not available; this placeholder text is used instead."
   },
 
+  "troubleshooting_header": {
+    "message": "Řešení problémů",
+    "description": "The header for the Troubleshooting section in Options."
+  },
+
+  "troubleshooting_authorizing": {
+    "message": "Máte problém s autorizací? Nahlédněte do",
+    "description": "Text that tells the user about troubleshooting guide."
+  },
+
+  "troubleshooting_guide": {
+    "message": "průvodce řešením problémů",
+    "description": "A link to the troubleshooting guide on GitHub."
+  },
+
+  "report_it": {
+    "message": "Pokud máte stále problém s rozšířením, nahlašte jej.",
+    "description": "Text about reporting the problem."
+  },
+
   "debug_enable_logs": {
     "message": "Zapnout logování. Logy jsou uloženy lokálně. Můžete je poslat spolu s hlášením o chybě, pokud chcete.",
     "description": "Text for a checkbox that enables logging."
+  },
+
+  "report_button": {
+    "message": "Nahlásit problém",
+    "description": "Text on the button that shows a debug information."
+  },
+
+  "debug_information": {
+    "message": "Zkopírujte tyto ladící informace, přidejte detailní kroky, jak problém reprodukovat a připojte screenshot.",
+    "description": "Text that tells the user what to write in debug information."
+  },
+
+  "report_create_issue": {
+    "message": "Poté vytvořte nový požadavek a vložte jej na",
+    "description": "Text that tells the user where to put a debug information."
   }
 }

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -180,7 +180,7 @@
   },
 
   "report_create_issue": {
-    "message": "Poté vytvořte nový issue na",
+    "message": "Poté vytvořte nový issue a vložte jej na",
     "description": "Text that tells the user where to put a debug information."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -169,12 +169,12 @@
     "description": "Text for a checkbox that enables logging."
   },
 
-  "report_button": {
+  "report_issue_button": {
     "message": "Report an issue",
     "description": "Text on the button that shows a debug information."
   },
 
-  "debug_information": {
+  "report_issue_steps": {
     "message": "Copy this debug information, add detailed steps on how to reproduce the problem, and attach a screenshot.",
     "description": "Text that tells the user what to write in debug information."
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -180,7 +180,7 @@
   },
 
   "report_create_issue": {
-    "message": "Then create a new issue and paste it at",
+    "message": "Then create a new issue and paste it in the issue tracker below.",
     "description": "Text that tells the user where to put a debug information."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -144,8 +144,43 @@
     "description": "When a user does not have access to a particular calendar, the event title is not available; this placeholder text is used instead."
   },
 
+  "troubleshooting_header": {
+    "message": "Troubleshooting",
+    "description": "The header for the Troubleshooting section in Options."
+  },
+
+  "troubleshooting_authorizing": {
+    "message": "Having problems authorizing? Consult the",
+    "description": "Text that tells the user about troubleshooting guide."
+  },
+
+  "troubleshooting_guide": {
+    "message": "troubleshooting guide",
+    "description": "A link to the troubleshooting guide on GitHub."
+  },
+
+  "report_it": {
+    "message": "If you continue to run into a problem, please report it.",
+    "description": "Text about reporting the problem."
+  },
+
   "debug_enable_logs": {
     "message": "Enable logging. Logs are stored locally. You may send them with a bug report if you choose.",
     "description": "Text for a checkbox that enables logging."
+  },
+
+  "report_button": {
+    "message": "Report an issue",
+    "description": "Text on the button that shows a debug information."
+  },
+
+  "debug_information": {
+    "message": "Copy this debug information, add detailed steps on how to reproduce the problem, and attach a screenshot.",
+    "description": "Text that tells the user what to write in debug information."
+  },
+
+  "report_create_issue": {
+    "message": "Then create a new issue and paste it at",
+    "description": "Text that tells the user where to put a debug information."
   }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -28,20 +28,21 @@
     </article>
 
     <article>
-      <!-- TODO(manas): i18n -->
-      <h2>Troubleshooting</h2>
+      <h2 class="i18n" data-msg="troubleshooting_header">Troubleshooting</h2>
       <section>
-        <p>Having problems authorizing? Consult the <a href="https://github.com/manastungare/google-calendar-crx/wiki/Troubleshooting">troubleshooting guide</a>.</p>
+        <p><span class="i18n" data-msg="troubleshooting_authorizing">Having problems authorizing? Consult the</span> <a href="https://github.com/manastungare/google-calendar-crx/wiki/Troubleshooting" class="i18n" data-msg="troubleshooting_guide">troubleshooting guide</a>.</p>
 
-        <p>If you continue to run into a problem, please report it.</p>
+        <p class="i18n" data-msg="report_it">If you continue to run into a problem, please report it.</p>
         <label><input class="option" type="checkbox" name="debug-enable-logs">
           <span class="i18n" data-msg="debug_enable_logs"></span>
         </label>
-        <p><button id="report-issue-button">Report an issue</button></p>
+		<p><button id="report-issue-button">
+          <span class="i18n" data-msg="report_issue_button">Report an issue</span></button>
+        </p>
         <div id="report-issue-steps">
-          Copy this debug information, add detailed steps on how to reproduce the problem, and attach a screenshot.
+          <span class="i18n" data-msg="report_issue_steps">Copy this debug information, add detailed steps on how to reproduce the problem, and attach a screenshot.</span>
           <p><textarea id="system-info" rows="25"></textarea></p>
-          <p>Then create a new issue and paste it at
+		  <p><span class="i18n" data-msg="report_create_issue">Then create a new issue and paste it at</span>
             <a href="https://github.com/manastungare/google-calendar-crx/issues">https://github.com/manastungare/google-calendar-crx/issues</a>.
           </p>
         </div>

--- a/src/options.html
+++ b/src/options.html
@@ -42,8 +42,8 @@
         <div id="report-issue-steps">
           <span class="i18n" data-msg="report_issue_steps">Copy this debug information, add detailed steps on how to reproduce the problem, and attach a screenshot.</span>
           <p><textarea id="system-info" rows="25"></textarea></p>
-		  <p><span class="i18n" data-msg="report_create_issue">Then create a new issue and paste it at</span>
-            <a href="https://github.com/manastungare/google-calendar-crx/issues">https://github.com/manastungare/google-calendar-crx/issues</a>.
+		  <p><span class="i18n" data-msg="report_create_issue">Then create a new issue and paste it in the issue tracker below.</span><br>
+            <a href="https://github.com/manastungare/google-calendar-crx/issues">https://github.com/manastungare/google-calendar-crx/issues</a>
           </p>
         </div>
         </div>


### PR DESCRIPTION
I added Troubleshooting strings for translation from Options. This should partially fix #246 and #371 (in all languages it needs to have these strings translated).