### PR TITLE
Add location on the event to help user see where they need to go

### DIFF
--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -209,6 +209,12 @@ h2 {
   padding: 6px;
 }
 
+.event-location {
+  color: #666;
+  font-size: 12px;
+  text-decoration: none;
+}
+
 .event-title {
   font-size: 14px;
   overflow: hidden;

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -391,7 +391,15 @@ browseraction.createEventDiv_ = function(event) {
       'src': chrome.extension.getURL('icons/ic_action_video.png')
     })).appendTo(eventDetails);
 
-  } else if (event.location) {
+  }
+
+  var eventTitle = $('<div>').addClass('event-title').text(event.title);
+  if (event.responseStatus == constants.EVENT_STATUS_DECLINED) {
+    eventTitle.addClass('declined');
+  }
+  eventTitle.appendTo(eventDetails);
+
+  if (event.location && !event.hangout_url) {
     $('<a>').attr({
       'href': 'https://maps.google.com?q=' + encodeURIComponent(event.location),
       'target': '_blank'
@@ -399,13 +407,6 @@ browseraction.createEventDiv_ = function(event) {
       'src': chrome.extension.getURL('icons/ic_action_place.png')
     })).appendTo(eventDetails);
   }
-
-  // The location icon goes before the title because it floats right.
-  var eventTitle = $('<div>').addClass('event-title').text(event.title);
-  if (event.responseStatus == constants.EVENT_STATUS_DECLINED) {
-    eventTitle.addClass('declined');
-  }
-  eventTitle.appendTo(eventDetails);
 
   if (event.allday && spansMultipleDays || isDetectedEvent) {
     $('<div>')

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -403,7 +403,7 @@ browseraction.createEventDiv_ = function(event) {
     $('<a>').attr({
       'href': 'https://maps.google.com?q=' + encodeURIComponent(event.location),
       'target': '_blank'
-    }).append('<span>' + event.location + '</span>').addClass('event-location').append($('<img>').addClass('location-icon').attr({
+    }).append($('<span>').text(event.location)).addClass('event-location').append($('<img>').addClass('location-icon').attr({
       'src': chrome.extension.getURL('icons/ic_action_place.png')
     })).appendTo(eventDetails);
   }

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -395,7 +395,7 @@ browseraction.createEventDiv_ = function(event) {
     $('<a>').attr({
       'href': 'https://maps.google.com?q=' + encodeURIComponent(event.location),
       'target': '_blank'
-    }).append($('<img>').addClass('location-icon').attr({
+    }).append('<span>' + event.location + '</span>').append($('<img>').addClass('location-icon').attr({
       'src': chrome.extension.getURL('icons/ic_action_place.png')
     })).appendTo(eventDetails);
   }

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -403,7 +403,7 @@ browseraction.createEventDiv_ = function(event) {
     $('<a>').attr({
       'href': 'https://maps.google.com?q=' + encodeURIComponent(event.location),
       'target': '_blank'
-    }).append('<span>' + event.location + '</span>').append($('<img>').addClass('location-icon').attr({
+    }).append('<span>' + event.location + '</span>').addClass('event-location').append($('<img>').addClass('location-icon').attr({
       'src': chrome.extension.getURL('icons/ic_action_place.png')
     })).appendTo(eventDetails);
   }


### PR DESCRIPTION
Pull Request for the issue #434

I added the `location` information under the `title` with this code :+1: 

```js
.append('<span>' + event.location + '</span>')
```

In the popup the effect is : 
![improve_location](https://cloud.githubusercontent.com/assets/3133477/18035184/b5601656-6d50-11e6-97b1-badbd5a30910.png)

This way the user can directly see where he needs to go for the following event.

I added the following condition : 
```js
if (event.location && !event.hangout_url)
```
To not add the location if a hangout has been planified. That we still have to workflow to only display Hangout and not the both information.


Dexterneo

