### PR TITLE
In the past

### DIFF
--- a/src/events_microformats.js
+++ b/src/events_microformats.js
@@ -131,10 +131,14 @@ function detectHCalendarEvents() {
     }
 
     event = utils.processEvent(event);
-    events.push(event);
 
-    // Insert a button inline near the title of the page.
-    $(vevent).find('.summary').prepend(getInlineIconSmall_(event));
+    var now = moment().valueOf();
+    if (event.end > now) {
+      events.push(event);
+      // Insert a button inline near the title of the page.
+      $(vevent).find('.summary').prepend(getInlineIconSmall_(event));
+    }
+
   });
 
   return events;

--- a/src/events_microformats.js
+++ b/src/events_microformats.js
@@ -133,7 +133,7 @@ function detectHCalendarEvents() {
     event = utils.processEvent(event);
 
     var now = moment().valueOf();
-    if (event.end > now) {
+    if (event.end >= now) {
       events.push(event);
       // Insert a button inline near the title of the page.
       $(vevent).find('.summary').prepend(getInlineIconSmall_(event));

--- a/src/events_microformats.js
+++ b/src/events_microformats.js
@@ -132,8 +132,7 @@ function detectHCalendarEvents() {
 
     event = utils.processEvent(event);
 
-    var now = moment().valueOf();
-    if (event.end >= now) {
+    if (event.end >= moment().valueOf()) {
       events.push(event);
       // Insert a button inline near the title of the page.
       $(vevent).find('.summary').prepend(getInlineIconSmall_(event));


### PR DESCRIPTION
Related to issue #227

With this PR, only detected event where the `end` is superior or egual to the actual date will be passed to the extension.
The icon will be displayed only for those events.