### PR TITLE
Add document icon for quickly accessing event attachments

### DIFF
--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -247,12 +247,18 @@ h2 {
   font-size: 13px;
 }
 
+.attachment-icon,
 .location-icon,
 .video-call-icon {
   float: right;
   height: 15px;
   padding: 0 3px;
   width: 21px;
+}
+
+.attachment-icon {
+  /* Desaturate attachment icons so they match the look of the other icons. */
+  filter: grayscale(100%);
 }
 
 .button {

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -450,6 +450,15 @@ browseraction.createEventDiv_ = function(event) {
 
   }
 
+  if (event.attachments) {
+    $('<a>').attr({
+      'href': event.attachments[0].fileUrl,
+      'target': '_blank'
+    }).append($('<img>').addClass('attachment-icon').attr({
+      'src': event.attachments[0].iconLink
+    })).appendTo(eventDetails);
+  }
+
   var eventTitle = $('<div>').addClass('event-title').text(event.title);
   if (event.responseStatus == constants.EVENT_STATUS_DECLINED) {
     eventTitle.addClass('declined');

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -451,6 +451,9 @@ browseraction.createEventDiv_ = function(event) {
   }
 
   if (event.attachments) {
+    // If there are multiple attachments, do nothing. This ideally would have
+    // a nice UI, but we can do without one because multiple attachments are
+    // the exception rather than the norm.
     $('<a>').attr({
       'href': event.attachments[0].fileUrl,
       'target': '_blank'

--- a/src/feeds.js
+++ b/src/feeds.js
@@ -342,6 +342,7 @@ feeds.fetchEventsFromCalendar_ = function(feed, callback) {
               allday: !end || (start.hours() === 0 && start.minutes() === 0 && end.hours() === 0 && end.minutes() === 0),
               location: eventEntry.location,
               hangout_url: eventEntry.hangoutLink,
+              attachments: eventEntry.attachments,
               gcal_url: eventEntry.htmlLink,
               responseStatus: responseStatus
             });


### PR DESCRIPTION
Make it possibly to quickly open a Google Doc associated with some event
by adding an icon to the event entry, à la the location and Hangout icons.

If there are multiple attachments, do nothing. This ideally would have a
nice UI, but I think it's OK because multiple attachments are the
exception.

Credit to @mrmcd for the idea.