### PR TITLE
Make the Gruntfile lint and format the code

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,14 @@
+{
+  "box-model": false,
+  "box-sizing": false,
+  "compatible-vendor-prefixes": false,
+  "fallback-colors": false,
+  "font-sizes": false,
+  "gradients": false,
+  "ids": false,
+  "order-alphabetical": false,
+  "outline-none": false,
+  "qualified-headings": false,
+  "universal-selector": false,
+  "vendor-prefix": false
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,30 @@
+{
+  "boss": true,
+  "browser": true,
+  "curly": true,
+  "devel": true,
+  "eqeqeq": false,
+  "eqnull": true,
+  "es5": true,
+  "evil": true,
+  "globalstrict": true,
+  "immed": true,
+  "jquery": true,
+  "latedef": true,
+  "loopfunc": true,
+  "newcap": true,
+  "noarg": true,
+  "node": true,
+  "noempty": true,
+  "nonew": true,
+  "strict": false,
+  "sub": true,
+  "trailing": true,
+  "undef": true,
+  "globals": {
+    "$": true,
+    "chrome": true,
+    "moment": true,
+    "_gaq": false
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,160 +15,28 @@
 
 
 module.exports = function(grunt) {
-  grunt.loadNpmTasks('grunt-closure-compiler');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-css');
+  grunt.loadNpmTasks('grunt-clang-format');
   grunt.loadNpmTasks('grunt-contrib-csslint');
   grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-
-  var closure_options = {
-    compilation_level: "ADVANCED_OPTIMIZATIONS",
-    debug: true,
-    externs: [
-      process.env.CLOSURE_PATH + '/contrib/externs/jquery-1.7.js',
-      process.env.CLOSURE_PATH + '/contrib/externs/chrome_extensions.js',
-      'externs.js'
-    ],
-    jscomp_error: [
-      "accessControls",
-      "ambiguousFunctionDecl",
-      "checkTypes",
-      "checkVars",
-      "externsValidation",
-      "globalThis",
-      "internetExplorerChecks",
-      "invalidCasts",
-      "missingProperties",
-      "nonStandardJsDocs",
-      "strictModuleDepCheck",
-      "unknownDefines",
-      "uselessCode",
-      "visibility"
-    ],
-    warning_level: "verbose"
-  };
-
-  var browser_action_files = [
-    'src/types.js',
-    'src/utils.js',
-    'src/versioning.js',
-    'src/browser_action.js'
-  ];
-
-  var background_page_files = [
-    'src/types.js',
-    'src/utils.js',
-    'src/feeds.js',
-    'src/options.js',
-    'src/scheduler.js',
-    'src/context_menu.js',
-    'src/background.js'
-  ];
-
-  var content_script_files = [
-    'src/types.js',
-    'src/utils.js',
-    'src/events_microformats.js'
-  ];
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
     jshint: {
-      options: {
-        boss: true,
-        browser: true,
-        curly: true,
-        devel: true,
-        eqeqeq: false,
-        eqnull: true,
-        es5: true,
-        evil: true,
-        globalstrict: true,
-        immed: true,
-        jquery: true,
-        latedef: true,
-        newcap: true,
-        noarg: true,
-        node: true,
-        noempty: true,
-        nonew: true,
-        strict: false,
-        sub: true,
-        trailing: true,
-        undef: true
-      },
-      globals: {
-        $: true,
-        chrome: true,
-        moment: true
-      }
+      options: {jshintrc: true},
+      all: ['*.js', 'src/*.js'],
     },
 
-    concat: {
-      background_page: {
-        src: background_page_files,
-        dest: 'bin/background_page.concat.js'
-      },
-      browser_action: {
-        src: browser_action_files,
-        dest: 'bin/browser_action.concat.js'
-      },
-      content_script: {
-        src: content_script_files,
-        dest: 'bin/content_script.concat.js'
-      }
-    },
+    csslint: {options: {csslintrc: '.csslintrc'}, all: {src: ['src/*.css']}},
 
-    jshint: {
-      background_page: 'bin/background_page.concat.js',
-      browser_action: 'bin/browser_action.concat.js',
-      content_script: 'bin/content_script.concat.js'
-    },
-
-    'closure-compiler': {
-      background_page: {
-        js: '<%= concat.background_page.dest %>',
-        jsOutputFile: 'bin/background_page.compiled.js',
-        options: closure_options
-      },
-      browser_action: {
-        js: '<%= concat.browser_action.dest %>',
-        jsOutputFile: 'bin/browser_action.compiled.js',
-        options: closure_options
-      },
-      content_script: {
-        js: '<%= concat.content_script.dest %>',
-        jsOutputFile: 'bin/content_script.compiled.js',
-        options: closure_options
-      }
-    },
-
-    csslint: {
-      all: {
-        src: [
-          '*.css'
-        ],
-        rules: {
-          'box-model': false,
-          'box-sizing': false,
-          'compatible-vendor-prefixes': false,
-          'fallback-colors': false,
-          'gradients': false,
-          'ids': false,
-          'qualified-headings': false,
-          'universal-selector': false,
-          'vendor-prefix': false,
-        }
-      }
+    clangFormat: {
+      src: ['*.js', 'src/*.js'],
     }
   });
 
   grunt.registerTask('default', [
-    'concat:*',
     'jshint:*',
     'csslint:*',
-    'closure-compiler:*'
+    'clangFormat:*',
   ]);
 };

--- a/externs.js
+++ b/externs.js
@@ -29,7 +29,7 @@ chrome.app.getDetails = function() {
  * @param {Array.<string>|string=} opt_formatString
  * return {Moment}
  */
-function moment(opt_date, opt_formatString) {};
+function moment(opt_date, opt_formatString) {}
 
 /**
  * @param {string} locale
@@ -42,7 +42,7 @@ moment.lang = function(locale, opt_languageStrings) {};
  * Externs for the Moment.js library.
  * @constructor
  */
-function Moment() {};
+function Moment() {}
 
 /** @return {string} */
 Moment.prototype.calendar = function() {};

--- a/package.json
+++ b/package.json
@@ -2,11 +2,9 @@
   "name": "google-calendar-crx",
   "version": "1.3.2",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-closure-compiler": "0.0.17",
-    "grunt-css": "~0.1",
-    "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-csslint": "~0.1.1"
+    "grunt": "~1.0.1",
+    "grunt-clang-format": "^1.0.0",
+    "grunt-contrib-csslint": "~2.0.0",
+    "grunt-contrib-jshint": "~1.1.0"
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/* globals options, feeds, utils, scheduler, constants */
 
 /**
  * @fileoverview Script that runs in the context of the background page.
@@ -61,7 +62,7 @@ background.eventsFromPage = {};
  *   title: (string|undefined)
  * }}
  */
-background.BadgeProperties;
+background.BadgeProperties;  // jshint ignore:line
 
 /**
  * A function that logs all its arguments to memory and to the console if the

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -222,7 +222,7 @@ h2 {
   white-space: nowrap;
 }
 
-.event-title.declined {
+.declined {
   text-decoration: line-through;
   color: #999;
 }

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -95,14 +95,14 @@ browseraction.fillMessages_ = function() {
 /** @private */
 browseraction.loadCalendarsIntoQuickAdd_ = function() {
   chrome.extension.getBackgroundPage().background.log('browseraction.loadCalendarsIntoQuickAdd_()');
-  chrome.storage.local.get('calendars', function(storage) {
+  chrome.storage.local.get(constants.CALENDARS_STORAGE_KEY, function(storage) {
     if (chrome.runtime.lastError) {
       chrome.extension.getBackgroundPage().background.log(
           'Error retrieving calendars:', chrome.runtime.lastError);
     }
 
-    if (storage.calendars) {
-      var calendars = storage.calendars;
+    if (storage[constants.CALENDARS_STORAGE_KEY]) {
+      var calendars = storage[constants.CALENDARS_STORAGE_KEY];
       var dropDown = $('#quick-add-calendar-list');
       for (var calendarId in calendars) {
         var calendar = calendars[calendarId];

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,3 +29,10 @@ constants.EVENT_STATUS_DECLINED = 'declined';
  * @const
  */
 constants.INFO_BAR_DISMISS_TIMEOUT_MS = 5000;
+
+/**
+ * The key under which the calendar list is stored in storage.
+ * @type {string}
+ * @const
+ */
+constants.CALENDARS_STORAGE_KEY = 'calendars';

--- a/src/context_menu.js
+++ b/src/context_menu.js
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/* globals utils */
 
 /**
  * @fileoverview Creates and handles context menus on web pages to let the user

--- a/src/events_microformats.js
+++ b/src/events_microformats.js
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/* globals utils */
 
 /**
  * @fileoverview Detects events from any page that contains hEvent

--- a/src/feeds.js
+++ b/src/feeds.js
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/* globals background, constants, options, utils */
+
 
 /**
  * @fileoverview Retrieves and parses a calendar feed from the server.
@@ -148,7 +150,7 @@ feeds.fetchCalendars = function() {
       background.log('Error retrieving settings: ', chrome.runtime.lastError.message);
     }
 
-    var storedCalendars = storage['calendars'] || {};
+    var storedCalendars = storage.calendars || {};
     chrome.identity.getAuthToken({'interactive': false}, function(authToken) {
       if (chrome.runtime.lastError) {
         chrome.extension.sendMessage({method: 'sync-icon.spinning.stop'});
@@ -232,14 +234,14 @@ feeds.fetchEvents = function() {
       return;
     }
 
-    if (!storage['calendars']) {
+    if (!storage.calendars) {
       // We don't have any calendars yet? Probably the first time.
       feeds.fetchCalendars();
       return;
     }
 
-    var calendars = storage['calendars'] || {};
-    background.log('storage[calendars]:', calendars);
+    var calendars = storage.calendars || {};
+    background.log('storage.calendars:', calendars);
 
     var hiddenCalendars = [];
     var allEvents = [];
@@ -407,13 +409,13 @@ feeds.updateNotification = function() {
         // If event has been changed, then update the alarm.
         if (feeds.nextEvents[i].start !== alarms[alarmIndex].scheduledTime + TIME_UNTIL_ALARM_MS) {
           chrome.alarms.clear(feeds.nextEvents[i].event_id);
-          chrome.alarms.create(feeds.nextEvents[i].event_id, {when: alarmSchedule})
+          chrome.alarms.create(feeds.nextEvents[i].event_id, {when: alarmSchedule});
         }
       } else {
         // Add new alarm
         chrome.alarms.create(
             feeds.nextEvents[i].event_id,
-            {when: new Date(feeds.nextEvents[i].start).getTime() - TIME_UNTIL_ALARM_MS})
+            {when: new Date(feeds.nextEvents[i].start).getTime() - TIME_UNTIL_ALARM_MS});
       }
     }
   });

--- a/src/feeds.js
+++ b/src/feeds.js
@@ -145,12 +145,12 @@ feeds.fetchCalendars = function() {
   background.log('feeds.fetchCalendars()');
   chrome.extension.sendMessage({method: 'sync-icon.spinning.start'});
 
-  chrome.storage.local.get('calendars', function(storage) {
+  chrome.storage.local.get(constants.CALENDARS_STORAGE_KEY, function(storage) {
     if (chrome.runtime.lastError) {
       background.log('Error retrieving settings: ', chrome.runtime.lastError.message);
     }
 
-    var storedCalendars = storage.calendars || {};
+    var storedCalendars = storage[constants.CALENDARS_STORAGE_KEY] || {};
     chrome.identity.getAuthToken({'interactive': false}, function(authToken) {
       if (chrome.runtime.lastError) {
         chrome.extension.sendMessage({method: 'sync-icon.spinning.stop'});
@@ -193,7 +193,9 @@ feeds.fetchCalendars = function() {
             calendars[serverCalendarID] = mergedCalendar;
           }
 
-          chrome.storage.local.set({'calendars': calendars}, function() {
+          var store = {};
+          store[constants.CALENDARS_STORAGE_KEY] = calendars;
+          chrome.storage.local.set(store, function() {
             if (chrome.runtime.lastError) {
               background.log('Error saving settings: ', chrome.runtime.lastError.message);
               return;
@@ -228,20 +230,20 @@ feeds.fetchEvents = function() {
   feeds.lastFetchedAt = new Date();
   background.updateBadge({'title': chrome.i18n.getMessage('fetching_feed')});
 
-  chrome.storage.local.get('calendars', function(storage) {
+  chrome.storage.local.get(constants.CALENDARS_STORAGE_KEY, function(storage) {
     if (chrome.runtime.lastError) {
       background.log('Error retrieving settings:', chrome.runtime.lastError.message);
       return;
     }
 
-    if (!storage.calendars) {
+    if (!storage[constants.CALENDARS_STORAGE_KEY]) {
       // We don't have any calendars yet? Probably the first time.
       feeds.fetchCalendars();
       return;
     }
 
-    var calendars = storage.calendars || {};
-    background.log('storage.calendars:', calendars);
+    var calendars = storage[constants.CALENDARS_STORAGE_KEY] || {};
+    background.log('storage[constants.CALENDARS_STORAGE_KEY]: ', calendars);
 
     var hiddenCalendars = [];
     var allEvents = [];

--- a/src/options.html
+++ b/src/options.html
@@ -38,6 +38,7 @@
 
     <script src="lib/jquery.min.js"></script>
     <script src="lib/moment+langs.min.js"></script>
+    <script src="constants.js"></script>
     <script src="utils.js"></script>
     <script src="options.js"></script>
   </body>

--- a/src/options.js
+++ b/src/options.js
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/*global background*/
 
 /**
  * @fileoverview Handles setting and getting options.
@@ -94,7 +95,8 @@ options.set = function(optionKey, optionValue) {
  */
 options.installAutoSaveHandlers = function() {
   var optionInputs = document.querySelectorAll(options.OPTIONS_WIDGET_SELECTOR_);
-  for (var i = 0, option; option = optionInputs[i]; ++i) {
+  for (var i = 0; i < optionInputs.length; ++i) {
+    var option = optionInputs[i];
     var type = option.getAttribute('type');
     if (type == 'checkbox') {
       option.addEventListener('change', function(event) {
@@ -140,14 +142,15 @@ options.writeDefaultsToStorage = function() {
  */
 options.loadOptionsUIFromSavedState = function() {
   var optionInputs = document.querySelectorAll(options.OPTIONS_WIDGET_SELECTOR_);
-  for (var i = 0, option; option = optionInputs[i]; ++i) {
+  for (var i = 0; i < optionInputs.length; ++i) {
+    var option = optionInputs[i];
     var type = option.getAttribute('type');
     var name = option.getAttribute('name');
     var value = options.get(name);
     if (type == 'checkbox') {
       option.checked = value ? 'checked' : '';
     } else {
-      if (value != null) {
+      if (value !== null) {
         option.value = value;
       }
     }
@@ -164,11 +167,12 @@ options.loadCalendarList = function() {
 
   chrome.storage.local.get('calendars', function(storage) {
     if (chrome.runtime.lastError) {
-      background.log('Error retrieving settings:', chrome.runtime.lastError);
+      chrome.extension.getBackgroundPage().background.log(
+          'Error retrieving settings:', chrome.runtime.lastError);
     }
 
-    if (storage['calendars']) {
-      var calendars = storage['calendars'];
+    if (storage.calendars) {
+      var calendars = storage.calendars;
 
       for (var calendarId in calendars) {
         var calendar = calendars[calendarId];
@@ -195,7 +199,7 @@ options.loadCalendarList = function() {
                   calendars[checkBox.attr('name')].visible = checkBox.is(':checked');
                   chrome.storage.local.set({'calendars': calendars}, function() {
                     if (chrome.runtime.lastError) {
-                      background.log(
+                      chrome.extension.getBackgroundPage().background.log(
                           'Error saving calendar list options.', chrome.runtime.lastError);
                       return;
                     }

--- a/src/options.js
+++ b/src/options.js
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-/*global background*/
+/*global background, constants*/
 
 /**
  * @fileoverview Handles setting and getting options.
@@ -165,14 +165,14 @@ options.loadOptionsUIFromSavedState = function() {
 options.loadCalendarList = function() {
   chrome.extension.getBackgroundPage().background.log('options.loadCalendarList()');
 
-  chrome.storage.local.get('calendars', function(storage) {
+  chrome.storage.local.get(constants.CALENDARS_STORAGE_KEY, function(storage) {
     if (chrome.runtime.lastError) {
       chrome.extension.getBackgroundPage().background.log(
           'Error retrieving settings:', chrome.runtime.lastError);
     }
 
-    if (storage.calendars) {
-      var calendars = storage.calendars;
+    if (storage[constants.CALENDARS_STORAGE_KEY]) {
+      var calendars = storage[constants.CALENDARS_STORAGE_KEY];
 
       for (var calendarId in calendars) {
         var calendar = calendars[calendarId];
@@ -197,7 +197,9 @@ options.loadCalendarList = function() {
                   checkBox.css(
                       {'background': checkBox.is(':checked') ? checkBox.attr('data-color') : ''});
                   calendars[checkBox.attr('name')].visible = checkBox.is(':checked');
-                  chrome.storage.local.set({'calendars': calendars}, function() {
+                  var store = {};
+                  store[constants.CALENDARS_STORAGE_KEY] = calendars;
+                  chrome.storage.local.set(store, function() {
                     if (chrome.runtime.lastError) {
                       chrome.extension.getBackgroundPage().background.log(
                           'Error saving calendar list options.', chrome.runtime.lastError);

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+/* globals feeds */
 
 /**
  * @fileoverview Performs operations that must be done on a schedule: e.g.
@@ -53,7 +54,7 @@ scheduler.BADGE_UPDATE_INTERVAL_MS_ = 60 * 1000;
  * the calendar (less often).
  */
 scheduler.start = function() {
-  background.log('scheduler.start()');
+  chrome.extension.getBackgroundPage().background.log('scheduler.start()');
 
   // Do a one-time initial fetch on load. Settings are only refreshed when restarting Chrome.
   feeds.fetchSettings();


### PR DESCRIPTION
* Add grunt-clang-format task to run clang-format on src/*.js.
* Remove grunt-closure-compiler, grunt-contrib-concat, grunt-css and
  grunt-contrib-uglify plugins and associated tasks. They were not in use, as
  far as I could determine.
* Move csslint and jshint rules into standalone .csslintrc and .jshintrc files.
* Update dependencies to latest stable version: grunt (~0.4.1 -> ~1.0.1),
  grunt-contrib-csslint (~0.1.1 -> ~2.0.0) and grunt-contrib-jshint
  (~0.1.1 -> ~1.1.0).
* Fix various JavaScript lint errors.