### PR TITLE
Start and end of event, adding some features, beautifying, closing issues

### DIFF
--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -214,12 +214,13 @@ h2 {
 
 .start-time {
   color: #fff;
-  flex: 0 0 66px;
+  flex: 0 0 50px;
   font-size: 12px;
   overflow: hidden;
-  text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  text-align: center;
+  white-space: pre-line;
+  display: inline-flex;
+  align-items: center;
 }
 
 .start-and-end-times {

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -207,7 +207,7 @@ h2 {
 
 .start-time {
   color: #fff;
-  flex: 0 0 50px;
+  flex: 0 0 60px;
   font-size: 12px;
   overflow: hidden;
   text-align: center;

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -50,7 +50,7 @@ header {
   height: 48px;
   background: #0086f4;
   padding: 12px;
-  position: fixed;
+  position: relative;
   width: 100%;
   top: 0;
   left: 0;
@@ -58,8 +58,20 @@ header {
   z-index: 10;
 }
 
-.header-placeholder {
-  height: 48px;
+.section-container {
+  display: flex;
+  overflow: hidden;
+  height: 432px;
+}
+
+section {
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  overflow: auto;
+  height: auto;
+  padding: .5rem;
 }
 
 .fab {

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -68,7 +68,7 @@ section {
   flex: 1;
   overflow: auto;
   height: auto;
-  padding: .5rem;
+  padding: 0 8px;
 }
 
 .fab {
@@ -132,10 +132,6 @@ section {
   padding: 8px;
   width: 100%;
   margin-bottom: 8px;
-}
-
-section {
-  padding: 0 8px;
 }
 
 #error {

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -14,9 +14,6 @@ body {
   margin: 0;
 }
 ::-webkit-scrollbar {
-  background: transparent;
-  height: 8px;
-  width: 8px;
 }
 
 ::-webkit-scrollbar:hover {
@@ -24,11 +21,6 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  background: #afafaf;
-  min-height: 40px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
@@ -65,9 +57,6 @@ header {
 }
 
 section {
-  -webkit-box-flex: 1;
-  -webkit-flex: 1;
-  -ms-flex: 1;
   flex: 1;
   overflow: auto;
   height: auto;

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -165,6 +165,7 @@ section {
   margin: 8px 0;
   padding: 16px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  border-radius: 2px;
 }
 
 h2 {
@@ -206,6 +207,7 @@ h2 {
   cursor: pointer;
   display: flex;
   margin: 0 0 4px 0;
+  border-radius: 2px;
   overflow: hidden;
   position: relative;
 }

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -13,16 +13,23 @@ body {
   padding: 0;
   margin: 0;
 }
+
+/* Customized Scrollbar */
 ::-webkit-scrollbar {
+  background: transparent; /* only show scrollbar-thumb with no background (clean appearance) */
+  width: 8px; /* same width as scrollbar from Google Calendar */
 }
 
 ::-webkit-scrollbar:hover {
-  background-color: rgba(0, 0, 0, 0.07);
+  background-color: rgba(0, 0, 0, 0.07); /* show "path" of scrollbar-thumb */
 }
 
 ::-webkit-scrollbar-thumb {
+  background: #afafaf; /* a bit darker as the original, because of the extensions background */
+  min-height: 40px; /* to make the scrollbar not too small. Maybe in the future it is possible to load more and more events */
 }
 
+/* Color changes on interaction */
 ::-webkit-scrollbar-thumb:hover {
   background: #a0a0a0
 }
@@ -50,6 +57,7 @@ header {
   z-index: 10;
 }
 
+/* Separate section from <header>, so only the section is a scrollable area */
 .section-container {
   display: flex;
   overflow: hidden;
@@ -207,7 +215,7 @@ h2 {
   font-size: 12px;
   overflow: hidden;
   text-align: center;
-  white-space: pre-line;
+  white-space: pre-line; /* start and end times vertically aligned */
   display: inline-flex;
   align-items: center;
 }

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -13,6 +13,31 @@ body {
   padding: 0;
   margin: 0;
 }
+::-webkit-scrollbar {
+  background: transparent;
+  height: 8px;
+  width: 8px;
+}
+
+::-webkit-scrollbar:hover {
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
+::-webkit-scrollbar-thumb {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background: #afafaf;
+  min-height: 40px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #a0a0a0
+}
+
+::-webkit-scrollbar-thumb:active {
+  background: #989898
+}
 
 textarea {
   border: 1px solid #ccc;

--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -16,17 +16,23 @@ body {
 
 /* Customized Scrollbar */
 ::-webkit-scrollbar {
-  background: transparent; /* only show scrollbar-thumb with no background (clean appearance) */
-  width: 8px; /* same width as scrollbar from Google Calendar */
+  /* Only show scrollbar-thumb with no background (clean appearance) */
+  background: transparent;
+  /* Same width as scrollbar from Google Calendar */
+  width: 8px;
 }
 
 ::-webkit-scrollbar:hover {
-  background-color: rgba(0, 0, 0, 0.07); /* show "path" of scrollbar-thumb */
+  /* Show "path" of scrollbar-thumb */
+  background-color: rgba(0, 0, 0, 0.07);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #afafaf; /* a bit darker as the original, because of the extensions background */
-  min-height: 40px; /* to make the scrollbar not too small. Maybe in the future it is possible to load more and more events */
+  /* A bit darker than the original, because of the extensions background */
+  background: #afafaf;
+  /* To make the scrollbar not too small.
+  Maybe in the future it is possible to load more and more events */
+  min-height: 40px;
 }
 
 /* Color changes on interaction */
@@ -211,7 +217,8 @@ h2 {
   font-size: 12px;
   overflow: hidden;
   text-align: center;
-  white-space: pre-line; /* start and end times vertically aligned */
+  /* Start and end times vertically aligned */
+  white-space: pre-line;
   display: inline-flex;
   align-items: center;
 }

--- a/src/browser_action.html
+++ b/src/browser_action.html
@@ -27,28 +27,29 @@
         <img width="24" height="24" src="icons/ic_add_white_24dp.png" id="show_quick_add" class="i18n">
       </div>
     </header>
-    <div class="header-placeholder"></div>
-    <section>
-      <a id="announcement_new_features" class="i18n" href="https://github.com/manastungare/google-calendar-crx/wiki/Changes" target="_blank"></a>
-      <div id="info_bar"></div>
-      <div id="error">
-        <p class="i18n" id="authorization_explanation"></p>
-        <p><button class="button i18n" id="authorization_required"></button></p>
-        <p>
-          <a class="i18n" id="problems" target="_blank"
-              href="https://github.com/manastungare/google-calendar-crx/wiki/Troubleshooting">Problems?</a>
-        </p>
-      </div>
-      <div id="quick-add">
-        <h2 class="i18n" id="add_an_event">Add an Event</h2>
-        <select id="quick-add-calendar-list"/>
-        <textarea id="quick-add-event-title" rows="5" tabindex="1"></textarea>
-        <div class="quick-add-buttons">
-          <button id="quick_add_button" class="button i18n" tabindex="2">Quick Add</button>
+    <div class="section-container">
+      <section>
+        <a id="announcement_new_features" class="i18n" href="https://github.com/manastungare/google-calendar-crx/wiki/Changes" target="_blank"></a>
+        <div id="info_bar"></div>
+        <div id="error">
+          <p class="i18n" id="authorization_explanation"></p>
+          <p><button class="button i18n" id="authorization_required"></button></p>
+          <p>
+            <a class="i18n" id="problems" target="_blank"
+                href="https://github.com/manastungare/google-calendar-crx/wiki/Troubleshooting">Problems?</a>
+          </p>
         </div>
-      </div>
-      <div id="detected-events"></div>
-      <div id="calendar-events"></div>
-    </section>
+        <div id="quick-add">
+          <h2 class="i18n" id="add_an_event">Add an Event</h2>
+          <select id="quick-add-calendar-list"/>
+          <textarea id="quick-add-event-title" rows="5" tabindex="1"></textarea>
+          <div class="quick-add-buttons">
+            <button id="quick_add_button" class="button i18n" tabindex="2">Quick Add</button>
+          </div>
+        </div>
+        <div id="detected-events"></div>
+        <div id="calendar-events"></div>
+      </section>
+    </div>
   </body>
 </html>

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -418,7 +418,7 @@ browseraction.createEventDiv_ = function(event) {
   var isDetectedEvent = !event.feed;
   var isHappeningNow = start.valueOf() < now && end.valueOf() >= now;
   var spansMultipleDays = (end.diff(start, 'seconds') > 86400);
-  if (event.allday) {
+  if (event.allday || !event.allday && spansMultipleDays) {
     eventDiv.addClass('all-day');
   }
   if (isDetectedEvent) {
@@ -488,7 +488,7 @@ browseraction.createEventDiv_ = function(event) {
         .appendTo(eventDetails);
   }
 
-  if (event.allday && spansMultipleDays || isDetectedEvent) {
+  if (event.allday && spansMultipleDays || !event.allday && spansMultipleDays || isDetectedEvent) {
     $('<div>')
         .addClass('start-and-end-times')
         .append(start.format(dateTimeFormat) + ' — ' + end.format(dateTimeFormat))

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -418,8 +418,10 @@ browseraction.createEventDiv_ = function(event) {
   var isDetectedEvent = !event.feed;
   var isHappeningNow = start.valueOf() < now && end.valueOf() >= now;
   var spansMultipleDays = (end.diff(start, 'seconds') > 86400);
-  var isMultiDayEventWithTime = (!event.allday && spansMultipleDays); // Not an all-day event implies that times are given.
-  if (event.allday || isMultiDayEventWithTime) { // Multi-day events with time should look like all-day events.
+  // Not an all-day event implies that times are given.
+  var isMultiDayEventWithTime = (!event.allday && spansMultipleDays);
+  // Multi-day events with time should look like all-day events.
+  if (event.allday || isMultiDayEventWithTime) {
     eventDiv.addClass('all-day');
   }
   if (isDetectedEvent) {
@@ -431,10 +433,10 @@ browseraction.createEventDiv_ = function(event) {
 
   var timeFormat =
       chrome.extension.getBackgroundPage().options.get('format24HourTime') ? 'HH:mm' : 'h:mma';
-  
-  if(event.allday) { // Choose the correct time format.
+
+  if (event.allday) {  // Choose the correct time format.
     var dateTimeFormat = 'MMM D, YYYY';
-  } else if(isDetectedEvent || isMultiDayEventWithTime) {
+  } else if (isDetectedEvent || isMultiDayEventWithTime) {
     var dateTimeFormat = 'MMM D, YYYY ' + timeFormat;
   } else {
     var dateTimeFormat = timeFormat;
@@ -452,7 +454,8 @@ browseraction.createEventDiv_ = function(event) {
     startTimeDiv.css({'background-color': event.feed.backgroundColor});
   }
   if (!event.allday && !isDetectedEvent && !spansMultipleDays) {
-    startTimeDiv.text(start.format(dateTimeFormat) + ' ' + end.format(dateTimeFormat)); // Start and end times for partial-day events.
+    // Start and end times for partial-day events.
+    startTimeDiv.text(start.format(dateTimeFormat) + ' ' + end.format(dateTimeFormat));
   }
   startTimeDiv.appendTo(eventDiv);
 
@@ -498,7 +501,8 @@ browseraction.createEventDiv_ = function(event) {
   }
 
   if (isDetectedEvent || spansMultipleDays || isMultiDayEventWithTime) {
-    // If an event spans over multiple days, show start and end dates and if given, show also times.
+    // If an event spans over multiple days,
+    // show start and end dates and if given, show also times.
     $('<div>')
         .addClass('start-and-end-times')
         .append(start.format(dateTimeFormat) + ' — ' + end.format(dateTimeFormat))
@@ -509,26 +513,27 @@ browseraction.createEventDiv_ = function(event) {
 
 // Search for a Google Calendar tab and re-use this one, if none exists, then create a new one.
 function goToCalendar(eventUrl) {
-  chrome.tabs.query({
-    // All URLs showing Calendar UI Home Screen, except '/eventedit/', so current edits of events are not discarded.
-    url : [
-            constants.CALENDAR_UI_URL + '*/day*',
-            constants.CALENDAR_UI_URL + '*/week*',
-            constants.CALENDAR_UI_URL + '*/month*',
-            constants.CALENDAR_UI_URL + '*/year*',
-            constants.CALENDAR_UI_URL + '*/agenda*',
-            constants.CALENDAR_UI_URL + '*/custom*'
-      ],
-    currentWindow: true // Only search in current window.
-  }, function (tabs) {
-    // If one or more tabs match these conditions, select the first one of them and open the event URL.
-    if (tabs.length > 0) {
-      chrome.tabs.update(tabs[0].id, {selected: true, url: eventUrl});
-    } else {
-      // No matches, create a new tab.
-      chrome.tabs.create({url: eventUrl});
-    }
-  });
+  chrome.tabs.query(
+      {
+        // All URLs showing Calendar UI Home Screen, except '/eventedit/',
+        // so current edits of events are not discarded.
+        url: [
+          constants.CALENDAR_UI_URL + '*/day*', constants.CALENDAR_UI_URL + '*/week*',
+          constants.CALENDAR_UI_URL + '*/month*', constants.CALENDAR_UI_URL + '*/year*',
+          constants.CALENDAR_UI_URL + '*/agenda*', constants.CALENDAR_UI_URL + '*/custom*'
+        ],
+        currentWindow: true  // Only search in current window.
+      },
+      function(tabs) {
+        // If one or more tabs match these conditions,
+        // select the first one of them and open the event URL.
+        if (tabs.length > 0) {
+          chrome.tabs.update(tabs[0].id, {selected: true, url: eventUrl});
+        } else {
+          // No matches, create a new tab.
+          chrome.tabs.create({url: eventUrl});
+        }
+      });
   return;
 }
 

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -430,8 +430,7 @@ browseraction.createEventDiv_ = function(event) {
 
   var timeFormat =
       chrome.extension.getBackgroundPage().options.get('format24HourTime') ? 'HH:mm' : 'h:mma';
-  var dateTimeFormat =
-      event.allday ? 'MMM D, YYYY' : (isDetectedEvent ? 'MMM D, YYYY ' + timeFormat : timeFormat);
+  var dateTimeFormat = event.allday ? 'MMM D, YYYY' : (isDetectedEvent ? 'MMM D, YYYY ' + timeFormat : (spansMultipleDays ? 'MMM D, YYYY ' + timeFormat : timeFormat));
   var startTimeDiv = $('<div>').addClass('start-time');
   if (isDetectedEvent) {
     startTimeDiv.append($('<img>').attr({
@@ -443,8 +442,8 @@ browseraction.createEventDiv_ = function(event) {
   } else {
     startTimeDiv.css({'background-color': event.feed.backgroundColor});
   }
-  if (!event.allday && !isDetectedEvent) {
-    startTimeDiv.text(start.format(dateTimeFormat));
+  if (!event.allday && !isDetectedEvent && !spansMultipleDays) {
+    startTimeDiv.text(start.format(dateTimeFormat) + ' ' + end.format(dateTimeFormat));
   }
   startTimeDiv.appendTo(eventDiv);
 

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -425,7 +425,7 @@ browseraction.createEventDiv_ = function(event) {
     eventDiv.addClass('detected-event');
   }
   eventDiv.on('click', function() {
-    chrome.tabs.create({'url': $(this).attr('data-url')});
+    goToCalendar($(this).attr('data-url'));
   });
 
   var timeFormat =
@@ -497,6 +497,25 @@ browseraction.createEventDiv_ = function(event) {
   return eventDiv;
 };
 
+function getGCalUrl() {
+  return "https://calendar.google.com/calendar/";
+}
+
+function isGCalUrl(url) {
+  return url.indexOf(getGCalUrl()) == 0;
+}
+
+function goToCalendar(eventUrl) {
+  chrome.tabs.getAllInWindow(undefined, function(tabs) {
+    for (var i = 0, tab; tab = tabs[i]; i++) {
+      if (tab.url && isGCalUrl(tab.url)) {
+        chrome.tabs.update(tab.id, {selected: true, url: eventUrl});
+        return;
+      }
+    }
+    chrome.tabs.create({url: eventUrl});
+  });
+}
 
 /**
  * When the popup is loaded, fetch the events in this tab from the


### PR DESCRIPTION
Before:
![gcal_2](https://user-images.githubusercontent.com/8047980/34134607-e0a61878-e45b-11e7-872a-91316765ece4.PNG)

After:
![gcal_1](https://user-images.githubusercontent.com/8047980/34134126-16389018-e459-11e7-804e-679848d25e9d.PNG)



- Show start and end time of events
These are vertically aligned and centered. (See screenshot: "Long location")
Closes #307 #308 #356 

- Display multi-day events with given times as all-day events
It bothered me, that events, that span over multiple days and that are not all-day events (because they have start and end times) were shown as "normal" events that last only a few hours long. Now, these are also displayed as all-day events with their start and end times. (See screenshot: "Multiple days event with times")

- Go to already existing Calendar tab, instead of creating one every time
Not that good, as I wanted it to be. Are there any JS functions on Google Calendar to open an event, without reloading the entire website?
Closes #461 

- Beautifying
`<header>` is now outside the entire scrolling view, so the scrollbar is only used for the events, which looks better. I also redesigned the scrollbar itself and added some rounded borders for events and `quick-add`.