### PR TITLE
Show calendar name on mouseover of events

### DIFF
--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -451,8 +451,9 @@ browseraction.createEventDiv_ = function(event) {
       'alt': chrome.i18n.getMessage('add_to_google_calendar')
     }));
   } else {
-    startTimeDiv.css({'background-color': event.feed.backgroundColor});
-    startTimeDiv.attr({'title': event.feed.title}); // Show calendar name on mouseover
+    startTimeDiv.css({'background-color': event.feed.backgroundColor}).attr({
+      'title': event.feed.title  // Show calendar name on mouseover
+    });
   }
   if (!event.allday && !isDetectedEvent && !spansMultipleDays) {
     // Start and end times for partial-day events.

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -452,6 +452,7 @@ browseraction.createEventDiv_ = function(event) {
     }));
   } else {
     startTimeDiv.css({'background-color': event.feed.backgroundColor});
+    startTimeDiv.attr({'title': event.feed.title}); // Show calendar name on mouseover
   }
   if (!event.allday && !isDetectedEvent && !spansMultipleDays) {
     // Start and end times for partial-day events.


### PR DESCRIPTION
![mouseover](https://user-images.githubusercontent.com/8047980/34312519-12bc585c-e765-11e7-9dab-9f9f58e4ee6c.png)

Just a small enhancement, because I lose track of my calendars and their corresponding colors sometimes.

(Formatted it like the line above, to keep things simple and small)