### PR TITLE
Prevent clicks on anchor tags within event div from propagating

### DIFF
--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -429,6 +429,9 @@ browseraction.createEventDiv_ = function(event) {
   }
   eventDiv.on('click', function() {
     browseraction.goToCalendar_($(this).attr('data-url'));
+  }).on('click', 'a', function(event) {
+    // Clicks on anchor tags shouldn't propagate to eventDiv handler.
+    event.stopPropagation();
   });
 
   var timeFormat =


### PR DESCRIPTION
Clicking on an attachment or a hangout icon should take you to that
attachment or hangout, rather than open the event in a calendar tab.
To do that, it is necessary to stop clicks on anchor tags from
propagating up the DOM.