### PR TITLE
DIsplay the event's location is the event has one

### DIFF
--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -558,7 +558,7 @@ browseraction.createEventDiv_ = function(event) {
   }
   eventTitle.appendTo(eventDetails);
 
-  if (event.location && !event.hangout_url) {
+  if (event.location) {
     $('<a>')
         .attr({
           'href': 'https://maps.google.com?q=' + encodeURIComponent(event.location),


### PR DESCRIPTION
In Issue #434 we found that the event's location is not displayed if the event also has a hangout url defined.

This small fix this behaviour.