### PR TITLE
Using Event Location value as the link when it's an HTTP URL

### DIFF
--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -529,7 +529,7 @@ browseraction.createEventDiv_ = function(event) {
         event.location :
         'https://maps.google.com?q=' + encodeURIComponent(event.location);
     $('<a>')
-        .attr({'href': url, 'target': '_blank', 'class': 'location-link'})
+        .attr({'href': url, 'target': '_blank'})
         .append($('<span>').text(event.location))
         .addClass('event-location')
         .append($('<img>').addClass('location-icon').attr({

--- a/src/browser_action.js
+++ b/src/browser_action.js
@@ -525,11 +525,11 @@ browseraction.createEventDiv_ = function(event) {
   eventTitle.appendTo(eventDetails);
 
   if (event.location) {
+    var url = event.location.match(/^https?:\/\//) ?
+        event.location :
+        'https://maps.google.com?q=' + encodeURIComponent(event.location);
     $('<a>')
-        .attr({
-          'href': 'https://maps.google.com?q=' + encodeURIComponent(event.location),
-          'target': '_blank'
-        })
+        .attr({'href': url, 'target': '_blank', 'class': 'location-link'})
         .append($('<span>').text(event.location))
         .addClass('event-location')
         .append($('<img>').addClass('location-icon').attr({


### PR DESCRIPTION
Sometimes, we have online meetings via zoom. That's a good idea add support to use the room IRL as location's hyperlink.