### PR TITLE
move add button up

### DIFF
--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -78,8 +78,8 @@ section {
 }
 
 .fab {
-  height: 42px;
-  width: 42px;
+  height: 38px;
+  width: 38px;
   cursor: pointer;
   border-radius: 50%;
   box-shadow: 0 0 4px rgba(0,0,0,.14), 0 4px 8px rgba(0,0,0,.28);
@@ -89,8 +89,8 @@ section {
   color: #fff;
   position: fixed;
   right: 16px;
-  top: 64px;
-  padding: 9px;
+  top: 50px;
+  padding: 7px;
   z-index: 10;
 }
 


### PR DESCRIPTION
Current implementation of the add button hides the conference icon on the topmost event. 
Made the following changes to prevent this.
1. Moved the add button up 14px, 
2. Reduced it's diameter by 4px

Before
<img width="200" src="https://user-images.githubusercontent.com/221584/58998602-692f0e80-87b6-11e9-8214-199fc2d902a4.png">
After
<img width="200" src="https://user-images.githubusercontent.com/221584/58999371-5585a700-87ba-11e9-8ab4-61ff5d052f80.png">