### PR TITLE
Fix Notification URL

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -229,10 +229,11 @@ chrome.alarms.onAlarm.addListener(function(alarm) {
  * Go to calendar on clicked
  */
 chrome.notifications.onClicked.addListener(function(alarmName) {
+  var alarm = JSON.parse(alarmName);
   var eventIndex = 0;
   feeds.events.some(function(event, index) {
     eventIndex = index;
-    return event.event_id === alarmName;
+    return event.event_id === alarm.event_id;
   });
   chrome.tabs.create({'url': feeds.events[eventIndex].gcal_url});
 });


### PR DESCRIPTION
Mentioned in #473 - when a notification is clicked, the wrong event is opened in the Calendar. 

it looks like in #518 the chrome alarm name was changed json. This prevents the correct calendar URL from ever being discovered in the onClicked listener, which then returns the URL for the last event in feeds.events.