### PR TITLE
Add “Checker Plus for Google Calendar” to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,6 @@ This Git repo will remain available, in case anyone is interested in forking it 
 
 There are several other extensions available that include similar features. Feel free to send pull requests editing this README to list your extension here.
 
-- Search the Chrome Extensions Store for [“calendar”](https://chrome.google.com/webstore/search/calendar)
+- [Checker Plus for Google Calendar](https://chrome.google.com/webstore/detail/checker-plus-for-google-c/hkhggnncdpfibdhinjiegagmopldibha)
+
+- Or search the Chrome Extensions Store for [“calendar”](https://chrome.google.com/webstore/search/calendar)


### PR DESCRIPTION
As instructed by the author I mentioned an alternative Google Calendar extension since this project is soon to be unpublished.